### PR TITLE
WIP Configurable default formatters for RAD reports

### DIFF
--- a/src/main/com/fulcrologic/rad/rendering/semantic_ui/formatters.cljc
+++ b/src/main/com/fulcrologic/rad/rendering/semantic_ui/formatters.cljc
@@ -1,0 +1,14 @@
+(ns com.fulcrologic.rad.rendering.semantic-ui.formatters
+  "Formatters for read-only values, such as in reports."
+  (:require
+    [com.fulcrologic.rad.type-support.decimal :as math]))
+
+;; TASK: More default type formatters
+(defn inst->human-readable-date
+  "Converts a UTC Instant into the correctly-offset and human-readable (e.g. America/Los_Angeles) date string."
+  [inst]
+  #?(:cljs
+     (when (inst? inst)
+       (.toLocaleDateString ^js inst js/undefined #js {:weekday "short" :year "numeric" :month "short" :day "numeric"}))))
+
+(def numeric->str math/numeric->str)

--- a/src/main/com/fulcrologic/rad/rendering/semantic_ui/semantic_ui_controls.cljc
+++ b/src/main/com/fulcrologic/rad/rendering/semantic_ui/semantic_ui_controls.cljc
@@ -3,6 +3,7 @@
    set SUI as the default control set."
   (:require
     [com.fulcrologic.rad.rendering.semantic-ui.form :as sui-form]
+    [com.fulcrologic.rad.rendering.semantic-ui.formatters :as formatters]
     [com.fulcrologic.rad.rendering.semantic-ui.entity-picker :as entity-picker]
     [com.fulcrologic.rad.rendering.semantic-ui.report :as sui-report]
     [com.fulcrologic.rad.rendering.semantic-ui.boolean-field :as boolean-field]
@@ -48,6 +49,13 @@
               :pick-many entity-picker/to-many-picker}}
 
    ;; Report-related controls
+   :com.fulcrologic.rad.report/type->formatter
+   {:string  (fn [report-instance value] value)
+    :instant (fn [report-instance value] (formatters/inst->human-readable-date value))
+    :int     (fn [report-instance value] (formatters/numeric->str value))
+    :decimal (fn [report-instance value] (formatters/numeric->str value))
+    :boolean (fn [report-instance value] (if value "true" "false"))}
+
    :com.fulcrologic.rad.report/style->layout
    {:default sui-report/render-table-report-layout
     :list    sui-report/render-list-report-layout}


### PR DESCRIPTION
Override `:com.fulcrologic.rad.report/type->formatter` to install
globally a custom formatter for a type.

A twin PR in fulcro-rad: https://github.com/fulcrologic/fulcro-rad/pull/33