### PR TITLE
Made enum render more robust

### DIFF
--- a/src/main/com/fulcrologic/rad/rendering/semantic_ui/enumerated_field.cljc
+++ b/src/main/com/fulcrologic/rad/rendering/semantic_ui/enumerated_field.cljc
@@ -31,7 +31,7 @@
     (let [props        (comp/props form-instance)
           read-only?   (form/read-only? form-instance attribute)
           options      (enumerated-options env attribute)
-          selected-ids (get props qualified-key #{})]
+          selected-ids (set (get props qualified-key))]
       (div :.ui.field {:key (str qualified-key)}
         (label (or field-label (some-> qualified-key name str/capitalize)))
         (div :.ui.middle.aligned.celled.list.big {:style {:marginTop "0"}}


### PR DESCRIPTION
Rad generated resolver for enum, using Datomic pull API, returns a vector of enums, but this field expected a set, which broke the field.

Perhaps the resolver should return a set, but this is a good robustness addition.