### PR TITLE
Add renderer for type :decimal and style :USD for form fields.

### DIFF
--- a/src/main/com/fulcrologic/rad/rendering/semantic_ui/currency_field.cljc
+++ b/src/main/com/fulcrologic/rad/rendering/semantic_ui/currency_field.cljc
@@ -1,0 +1,17 @@
+(ns com.fulcrologic.rad.rendering.semantic-ui.currency-field
+ (:require
+   [com.fulcrologic.fulcro.components :as comp]
+   [com.fulcrologic.fulcro.dom.inputs :as inputs]
+   [clojure.string :as str]
+   [com.fulcrologic.rad.rendering.semantic-ui.field :refer [render-field-factory]]
+   [com.fulcrologic.rad.type-support.decimal :as math]))
+
+(def ui-currency-input
+  (comp/factory (inputs/StringBufferedInput ::DecimalInput
+                                            {:model->string (fn [n]
+                                                              (math/numeric->currency-str n))
+                                             :string->model (fn [s]
+                                                              (math/numeric (str/replace s #"[$,]" "")))
+                                             :string-filter (fn [s] s)})))
+
+(def render-field (render-field-factory {} ui-currency-input))

--- a/src/main/com/fulcrologic/rad/rendering/semantic_ui/decimal_field.cljc
+++ b/src/main/com/fulcrologic/rad/rendering/semantic_ui/decimal_field.cljc
@@ -8,7 +8,7 @@
 
 (def ui-decimal-input
   (comp/factory (inputs/StringBufferedInput ::DecimalInput
-                  {:model->string (fn [n] (if (math/numeric? n) (math/numeric->str n) ""))
+                  {:model->string (fn [n] (math/numeric->str n))
                    :string->model (fn [s] (math/numeric s))
                    :string-filter (fn [s] (str/replace s #"[^\d.]" ""))})))
 

--- a/src/main/com/fulcrologic/rad/rendering/semantic_ui/semantic_ui_controls.cljc
+++ b/src/main/com/fulcrologic/rad/rendering/semantic_ui/semantic_ui_controls.cljc
@@ -18,7 +18,8 @@
     [com.fulcrologic.rad.rendering.semantic-ui.enumerated-field :as enumerated-field]
     [com.fulcrologic.rad.rendering.semantic-ui.blob-field :as blob-field]
     [com.fulcrologic.rad.rendering.semantic-ui.autocomplete :as autocomplete]
-    [com.fulcrologic.rad.rendering.semantic-ui.text-field :as text-field]))
+    [com.fulcrologic.rad.rendering.semantic-ui.text-field :as text-field]
+    [com.fulcrologic.rad.rendering.semantic-ui.currency-field :as currency-field]))
 
 (def all-controls
   {;; Form-related UI
@@ -44,7 +45,8 @@
               :com.fulcrologic.rad.blob/file-upload blob-field/render-file-upload}
     :int     {:default int-field/render-field}
     :long    {:default int-field/render-field}
-    :decimal {:default decimal-field/render-field}
+    :decimal {:default decimal-field/render-field
+              :USD     currency-field/render-field}
     :boolean {:default boolean-field/render-field}
     :instant {:default      instant/render-field
               :date-at-noon instant/render-date-at-noon-field}


### PR DESCRIPTION
Hi,

There are two commits, one is for implementing the currency rendering when the type is :decimal and :style :USD in form fields.

The second commit is a bug fix when the type is :decimal and :style :default, to allow default values to be displayed in the form.

Thanks,
Murtaza