### PR TITLE
Bug fix for read-only text and enumerated field controls.

### DIFF
--- a/src/main/com/fulcrologic/rad/rendering/semantic_ui/enumerated_field.cljc
+++ b/src/main/com/fulcrologic/rad/rendering/semantic_ui/enumerated_field.cljc
@@ -66,7 +66,7 @@
                  (when invalid? (str " (" (tr "Required") ")"))))
         (if read-only?
           (let [value (first (filter #(= value (:value %)) options))]
-            (dom/input {:readOnly ""
+            (dom/input {:readOnly "readonly"
                         :value    (:text value)}))
           (ui-wrapped-dropdown (merge
                                  {:options  options

--- a/src/main/com/fulcrologic/rad/rendering/semantic_ui/field.cljc
+++ b/src/main/com/fulcrologic/rad/rendering/semantic_ui/field.cljc
@@ -36,11 +36,9 @@
              (when validation-message (str ent/nbsp "(" validation-message ")")))
            (div :.ui.input
              (input-factory (merge addl-props
-                              (cond->
-                                {:value    value
-                                 :onBlur   (fn [v] (form/input-blur! env qualified-key v))
-                                 :onChange (fn [v] (form/input-changed! env qualified-key v))}
-                                read-only? (assoc :readOnly "")))))
+                              {:value    value
+                               :onBlur   (fn [v] (form/input-blur! env qualified-key v))
+                               :onChange (fn [v] (form/input-changed! env qualified-key v))})))
            #_(when validation-message
                (div :.ui.error.message
                  (str validation-message)))))))))


### PR DESCRIPTION
I spotted a small issue where read-only text and enumerated fields aren't displayed as read only. This should fix it.

BTW I pulled out the cond-> in field.cljc because the readonly attribute is already added at line 30 when it's needed.