### PR TITLE
Respect report control's :visible?

### DIFF
--- a/src/main/com/fulcrologic/rad/rendering/semantic_ui/report.cljc
+++ b/src/main/com/fulcrologic/rad/rendering/semantic_ui/report.cljc
@@ -136,7 +136,9 @@
                              "ui right floated buttons")}
             (keep (fn [k]
                     (let [control (get controls k)]
-                      (when (or (not controlled?) (:local? control))
+                      (when (and (or (not controlled?) (:local? control))
+                                 (-> (get control :visible? true)
+                                     (?! report-instance)))
                         (control/render-control report-instance k control))))
               action-layout)))
         (div :.ui.form


### PR DESCRIPTION
Useful if you want to make the control visible in some cases only
(and thus include it in the layout).
This is in addition to making it always hidden by exluding it from
the layout and :visible? false, see
fulcrologic/fulcro-rad#62