### PR TITLE
Fix :ending-date style control to correctly initialize the value

### DIFF
--- a/src/main/com/fulcrologic/rad/rendering/semantic_ui/controls/instant_inputs.cljc
+++ b/src/main/com/fulcrologic/rad/rendering/semantic_ui/controls/instant_inputs.cljc
@@ -27,7 +27,8 @@
   "Display the date the user selects, but control a value that is midnight on the next date. Used for generating ending
   instants that can be used for a proper non-inclusive end date."
   [_ {:keys [value onChange] :as props}]
-  (let [today        (dt/inst->local-datetime (or value (dt/now)))
+  (let [today        (or (some-> value dt/inst->local-datetime)
+                         (ld/at-start-of-day (ldt/plus-days (ld/now) 1)))
         display-date (ldt/to-local-date (ldt/minus-days today 1))
         value        (dt/local-date->html-date-string display-date)]
     (dom/input
@@ -37,8 +38,7 @@
          :onChange (fn [evt]
                      (when onChange
                        (let [date-string (evt/target-value evt)
-                             tomorrow    (ld/at-time (ld/plus-days (dt/html-date-string->local-date date-string) 1)
-                                           lt/midnight)
+                             tomorrow    (ld/at-start-of-day (ld/plus-days (dt/html-date-string->local-date date-string) 1))
                              instant     (dt/local-datetime->inst tomorrow)]
                          (onChange instant))))}))))
 


### PR DESCRIPTION
When you initially render this style of control the value (being `nil`) defaults to `dt/now`.

Let's say currently it's `2021-11-10T19:32:44`.

`today` becomes `2021-11-10`, then the `display-date` becomes `2021-11-09`, which is not correct, because 1 day is substracted.

When you actually pick Nov 10th date from the picker, 1 day is added so the value, so the value becomes actually `2021-11-11` and then the substraction makes sense.

I have fixed the initial value to be like when the onChange logic, you the initial value is midnight of tomorrow.