### PR TITLE
Fix ui-ending-date-instant-input handling nils

### DIFF
--- a/src/main/com/fulcrologic/rad/rendering/semantic_ui/controls/instant_inputs.cljc
+++ b/src/main/com/fulcrologic/rad/rendering/semantic_ui/controls/instant_inputs.cljc
@@ -40,11 +40,11 @@
          :type     "date"
          :onChange (fn [evt]
                      (when onChange
-                       (let [date-string (evt/target-value evt)
-                             tomorrow    (ld/at-time (ld/plus-days (dt/html-date-string->local-date date-string) 1)
-                                           lt/midnight)
-                             instant     (dt/local-datetime->inst tomorrow)]
-                         (onChange instant))))}))))
+                       (onChange (some-> (evt/target-value evt)
+                                         (dt/html-date-string->local-date)
+                                         (ld/plus-days 1)
+                                         (ld/at-time lt/midnight)
+                                         (dt/local-datetime->inst)))))}))))
 
 (defn ui-date-time-instant-input [_ {:keys [disabled? value onChange] :as props}]
   (let [value (if (nil? value) "" (dt/inst->html-datetime-string value))]


### PR DESCRIPTION
Date inputs using `:style         :ending-date`
<img width="228" alt="Screenshot 2022-01-09 at 14 28 29" src="https://user-images.githubusercontent.com/4920654/148684203-e8befb85-f1ef-4840-91d8-ad51449ed2b1.png">
crashed after clicking "clear" with this error:
<img width="1294" alt="Screenshot 2022-01-09 at 14 12 27" src="https://user-images.githubusercontent.com/4920654/148684213-ba6458c7-ac47-417a-b378-6fcaa100f5f7.png">
