### PR TITLE
Allow negative numbers in decimal field

### DIFF
--- a/src/main/com/fulcrologic/rad/rendering/semantic_ui/decimal_field.cljc
+++ b/src/main/com/fulcrologic/rad/rendering/semantic_ui/decimal_field.cljc
@@ -10,6 +10,8 @@
   (comp/factory (inputs/StringBufferedInput ::DecimalInput
                   {:model->string (fn [n] (math/numeric->str n))
                    :string->model (fn [s] (math/numeric s))
-                   :string-filter (fn [s] (str/replace s #"[^\d.]" ""))})))
+                   :string-filter (fn [s] (-> (str/replace s #"[^\d.-]" "")
+                                              (str/replace #"(.)-" "$1")
+                                              (str/replace #"(\.\d*)\." "$1")))})))
 
 (def render-field (render-field-factory {} ui-decimal-input))


### PR DESCRIPTION
Current decimal field allows only digits and dot. 

This patch: changes the `:string-filter` to 
1. allow minus sign at the beginning of the string 
2. remove minus sign elsewhere
3. do not allow multiple dots inside the string

I also played with filter to replace `-.123` to `-0.123` but I found it obtrusive, as you have to first insert new number before dot and then you can remove 0 which could be annoying.

What do you think about new filters 2 and 3? Is not it too much? Generally I would only disable `[^-.\d]` characters and then use validations to highlight mal-formatted numbers which cannot be parsed.

ps: sorry for long time silence. I was busy with family life and non-Fulcro parts of my project. Hope to return to other pull requests soon (sql etc).


 