### PR TITLE
Keep form buttons from partially disappearing when screen is small

### DIFF
--- a/src/main/com/fulcrologic/rad/rendering/semantic_ui/form.cljc
+++ b/src/main/com/fulcrologic/rad/rendering/semantic_ui/form.cljc
@@ -341,10 +341,12 @@
                              (?! (suo/get-rendering-options form-instance suo/controls-class) env)
                              (?! (comp/component-options form-instance ::controls-class) env)
                              "ui top attached segment")}
-            (dom/h3 :.ui.header
-              title
-              (div :.ui.right.floated.buttons
-                (keep #(control/render-control master-form %) action-buttons))))
+            (div :.ui.stackable.grid
+              (div :.ui.eight.wide.column
+                (dom/h3 :.ui.header title))
+              (div :.ui.eight.wide.right.aligned.column
+                (div :.ui.buttons
+                  (keep #(control/render-control master-form %) action-buttons)))))
           (div {:classes [(or (?! (comp/component-options form-instance ::form-class) env) "ui attached form")
                           (when invalid? "error")]}
             (div :.ui.error.message (tr "The form has errors and cannot be saved."))

--- a/src/main/com/fulcrologic/rad/rendering/semantic_ui/form.cljc
+++ b/src/main/com/fulcrologic/rad/rendering/semantic_ui/form.cljc
@@ -341,12 +341,13 @@
                              (?! (suo/get-rendering-options form-instance suo/controls-class) env)
                              (?! (comp/component-options form-instance ::controls-class) env)
                              "ui top attached segment")}
-            (div :.ui.stackable.grid
-              (div :.ui.eight.wide.column
-                (dom/h3 :.ui.header title))
-              (div :.ui.eight.wide.right.aligned.column
-                (div :.ui.buttons
-                  (keep #(control/render-control master-form %) action-buttons)))))
+               (div {:style {:display "flex"
+                             :justify-content "space-between"
+                             :flex-wrap "wrap"}}
+                 (dom/h3 :.ui.header {:style {:word-wrap "break-word" :max-width "100%"}}
+                   title)
+                 (div :.ui.buttons {:style {:text-align "right" :display "inline" :flex-grow "1"}}
+                   (keep #(control/render-control master-form %) action-buttons))))
           (div {:classes [(or (?! (comp/component-options form-instance ::form-class) env) "ui attached form")
                           (when invalid? "error")]}
             (div :.ui.error.message (tr "The form has errors and cannot be saved."))


### PR DESCRIPTION
Removes floating property from form buttons (which prevents them from expanding their container when needed. Instead grid is used that is stackable (responsive) and column is aligned.

Before:

<img width="214" alt="image" src="https://user-images.githubusercontent.com/3322433/194940271-cbc03306-24ee-4895-8ba0-fe67f7de4b57.png">



After:

<img width="223" alt="image" src="https://user-images.githubusercontent.com/3322433/194940203-57cee961-bfb9-4f81-ba81-8b107041488b.png">
