### PR TITLE
ToOnePicker styling of buttons

### DIFF
--- a/src/main/com/fulcrologic/rad/rendering/semantic_ui/entity_picker.cljc
+++ b/src/main/com/fulcrologic/rad/rendering/semantic_ui/entity_picker.cljc
@@ -166,12 +166,14 @@
         (div {:className (or top-class "ui field")
               :classes   [(when invalid? "error")]}
           (dom/label field-label (when invalid? (str " (" (tr "Required") ")")))
-          (if read-only?
+         (if read-only?
             (let [value (first (filter #(= value (:value %)) options))]
               (:text value))
-            (comp/fragment {}                               ; FIXME: CSS help pls
+            (dom/div :.ui.small.menu {:style {:marginTop 0}}
               (ui-wrapped-dropdown (merge extra-props
-                                     {:onChange  (fn [v] (onSelect v))
+                                     {:style {:flexGrow 1}
+                                      :className "item"
+                                      :onChange  (fn [v] (onSelect v))
                                       :compact   true
                                       :value     value
                                       :clearable (not required?)
@@ -185,17 +187,17 @@
                                                                     :parent-relation-attribute attr
                                                                     :Form                      Form
                                                                     :ident                     [target-id-key id]})])))]
-                  (comp/fragment {}
+                  (dom/div :.icon.menu ; .right ?
                     (ui-creation-container (merge env
                                              {::form/parent          form-instance
                                               ::form/parent-relation qualified-key
                                               :Form                  Form}))
                     (when can-create?
-                      (dom/button :.ui.basic.icon.button
+                      (dom/button :.vertically.fitted.ui.icon.button.item
                         {:onClick (fn [] (open-editor! (tempid/tempid)))}
                         (dom/i :.plus.icon)))
                     (when can-edit?
-                      (dom/button :.ui.basic.icon.button
+                      (dom/button :.vertically.fitted.ui.icon.button.item
                         {:disabled (not (second value))
                          :onClick  (fn []
                                      (when-let [id (some-> value second)]


### PR DESCRIPTION
Notes: tiny menu so it is not higher than the date selector next to it. I did not fidn better way to get rid of the menu top margin and to make the dropdown use the available space thant inline style but my semantic-fu is very rudimentary.

<img width="662" alt="Screenshot 2022-12-31 at 10 17 57" src="https://user-images.githubusercontent.com/624958/210134200-ebf5b711-03b4-4f36-9d60-ff5d43259bfb.png">
