### PR TITLE
Picker: refactor to use ui-form-modal

### DIFF
--- a/src/main/com/fulcrologic/rad/rendering/semantic_ui/components.cljc
+++ b/src/main/com/fulcrologic/rad/rendering/semantic_ui/components.cljc
@@ -80,7 +80,10 @@
                                               (when userOnChange
                                                 (userOnChange value)))
                                             (catch :default e
-                                              (log/debug "Unable to read dropdown value " e (when v (.-value v))))))})]
+                                              ;; Note: With allowAdditions enabled the value will be the raw user-typed string, not transit-encoded
+                                              ;; clj value. We can this safely ignore its error here and assume the user handles it in :onAddItem
+                                              (when-not (and (.-allowAdditions v) (not (.find (.-options v) #(= (.-value %) (.-value v)))))
+                                                (log/debug "Unable to read dropdown value " e (when v (.-value v)))))))})]
        (ui-dropdown props))
      :clj
      (dom/div :.ui.selection.dropdown


### PR DESCRIPTION
* this fixes a bug where ALL modals in the same form would open all at once

I turned the pickers into a hooks component so that I could store `:ui/open?` on it to display/hide the modal. This required replacing the onMount... with use-lifecycle. Otherwise it seems to work fine.
