### PR TITLE
Picker quick create: dedupe pk

### DIFF
--- a/src/main/com/fulcrologic/rad/rendering/semantic_ui/entity_picker.cljc
+++ b/src/main/com/fulcrologic/rad/rendering/semantic_ui/entity_picker.cljc
@@ -75,7 +75,9 @@
   (remote [env]
     (let [delta {ident (reduce-kv
                          (fn [m k v]
-                           (assoc m k {:after v}))
+                           (if (= k (first ident))
+                             m
+                             (assoc m k {:after v})))
                          {}
                          entity)}]
       (-> env


### PR DESCRIPTION
Do not send diff for the <entity>/id as this is not necessary and breaks the SQL adapter, that tries to insert the same column twice.