### PR TITLE
Fix subform rendering (regression in RC1 6df316c)

### DIFF
--- a/src/main/com/fulcrologic/rad/rendering/semantic_ui/form.cljc
+++ b/src/main/com/fulcrologic/rad/rendering/semantic_ui/form.cljc
@@ -260,12 +260,10 @@
     (render-single-file env attr options)))
 
 (defn render-attribute [env attr options]
-  (let [{k ::attr/qualified-key} attr
-        subforms (fo/subform-options options attr)]
-    (if (contains? subforms k)
-      (let [render-ref (or (form/ref-container-renderer env attr) standard-ref-container)]
-        (render-ref env attr options))
-      (form/render-field env attr))))
+  (if (fo/subform-options options attr)
+    (let [render-ref (or (form/ref-container-renderer env attr) standard-ref-container)]
+      (render-ref env attr options))
+    (form/render-field env attr)))
 
 (def n-fields-string {1 "one field"
                       2 "two fields"


### PR DESCRIPTION
After upgrade to latest RCs of  fulcro, fulcro-rad and fulcro-rad-semantic-ui my subforms stopped rendering.

I investigated the issue and with the help of debugger I found `render-attribute` function which looked suspicious. It retrieves a qualified key atribute, gets its subform. `subform-options` with two parameters return subform config for second parameter which is k or ref attribute. Then it tests if the subform config contains that qualified key. Strange.

However I was puzzled why `new-rendering` branch of `fulcro-rad-demo` still works with this bug. Only later I found it uses multimethods to avoid it. 

This small patch fixed the issue for my code.

