### PR TITLE
Update :keyfn for row-factory in TableReportLayout

### DIFF
--- a/src/main/com/fulcrologic/rad/rendering/semantic_ui/report.cljc
+++ b/src/main/com/fulcrologic/rad/rendering/semantic_ui/report.cljc
@@ -357,7 +357,9 @@
 (comp/defsc TableReportLayout [this {:keys [report-instance] :as env}]
   {:initLocalState        (fn [this] {:row-factory (memoize (fn [cls] (comp/computed-factory cls
                                                                         {:keyfn (fn [props]
-                                                                                  (some-> props (comp/get-computed ::report/idx)))})))})
+                                                                                  (some-> props
+                                                                                    (comp/get-computed ::report/idx)
+                                                                                    (str "-" (comp/get-ident cls props))))})))})
    :shouldComponentUpdate (fn [_ _ _] true)}
   (let [{::report/keys [rotate?]} (comp/component-options report-instance)
         rotate?         (?! rotate? report-instance)


### PR DESCRIPTION
- When there is pagination in a report the row wasn't updating correctly (like for componentDidMount) because the key of the component was the same.